### PR TITLE
Hardening improvements

### DIFF
--- a/src/decoder.v
+++ b/src/decoder.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module decoder (
   input [15:0] instr,

--- a/src/divider.v
+++ b/src/divider.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module divider (
   input         clk,
@@ -32,4 +35,3 @@ module divider (
   assign pclk = pen;
 
 endmodule
-

--- a/src/fifo.v
+++ b/src/fifo.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module fifo (
   input             clk,
@@ -43,4 +46,3 @@ module fifo (
   assign level = count;
 
 endmodule
-

--- a/src/isr.v
+++ b/src/isr.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module isr (
   input         clk,

--- a/src/machine.v
+++ b/src/machine.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module machine (
   input         clk,

--- a/src/machine.v
+++ b/src/machine.v
@@ -278,9 +278,11 @@ module machine (
 
   // Count down if delay
   always @(posedge clk) begin
-    if (reset || restart) 
+    if (reset || restart) begin
       delay_cnt <= 0;
-    else if (en & penable) begin
+      pin_directions <= 32'h00000000;
+      output_pins <= 32'h00000000;
+    end else if (en & penable) begin
       exec1 <= exec; // Do execition on next cycle after exec set
       exec_instr <= new_val;
       if (delaying) delay_cnt <= delay_cnt - 1;

--- a/src/machine.v
+++ b/src/machine.v
@@ -290,9 +290,8 @@ module machine (
  
   integer i;
 
-  // Set output pins and pin directions TODO Move this to PIO and merge output values from machines
   always @(posedge clk) begin
-    if (enabled && !delaying) begin // TODO Set mask to allow multiplex of results from multiple machines
+    if (enabled && !delaying) begin
       if (sideset_enabled && !(auto && !waiting)) // TODO Is auto test correct?
         for (i=0;i<5;i++) 
           if (pins_side_count > i) output_pins[pins_side_base+i] <= side_set[i];
@@ -566,4 +565,3 @@ module machine (
   );
 
 endmodule
-

--- a/src/osr.v
+++ b/src/osr.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module osr (
   input         clk,
@@ -45,4 +48,3 @@ module osr (
   assign shift_count = count;
 
 endmodule
-

--- a/src/pc.v
+++ b/src/pc.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module pc (
   input        clk,

--- a/src/pio.v
+++ b/src/pio.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module pio #(
   parameter NUM_MACHINES = 4

--- a/src/pio.v
+++ b/src/pio.v
@@ -207,6 +207,7 @@ module pio #(
                  isr_threshold[mindex] <= din[24:20];
                  osr_threshold[mindex] <= din[29:25];
                end
+        NONE  : dout <= 32'h01000000; // Hardware version number
       endcase
     end
   end

--- a/src/scratch.v
+++ b/src/scratch.v
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Lawrie Griffiths
+// SPDX-License-Identifier: BSD-2-Clause
+
 `default_nettype none
 module scratch (
   input         clk,


### PR DESCRIPTION
This patchset includes some improvements I made while preparing this to be incorporated into a Skywater shuttle run:

* BSD license attached to all source files
* Return a version number when reading from the NONE register
* Initialize values on device reset
* Support coalescing multiple PIO outputs

It has not yet been proven in silicon, but it has been run through a testbench and I will be attempting to submit it as part of MPW-8.