### PR TITLE
fix MOV source X for dest PINS

### DIFF
--- a/src/machine.v
+++ b/src/machine.v
@@ -404,7 +404,7 @@ module machine (
               end
         MOV:  case (destination)  // Destination TODO Status source
                 0: case (mov_source) // PINS
-                     1: pins_out(bit_op(in_pins, mov_op));   // x
+                     1: pins_out(bit_op(x, mov_op));         // X
                      2: pins_out(bit_op(y, mov_op));         // Y
                      3: pins_out(bit_op(null, mov_op));      // NULL
                      6: pins_out(bit_op(in_shift, mov_op));  // ISR


### PR DESCRIPTION
I think `pins_out()` task should be referring to "X" in the first case instead of `in_pins()`. This at least gets the `CPHA=1` SPI example program from the Rpi repo working correctly.